### PR TITLE
Update logout api to accept access token in request body

### DIFF
--- a/src/controllers/authenticationController.js
+++ b/src/controllers/authenticationController.js
@@ -55,6 +55,12 @@ export default class AuthenticationController {
     logger.info('Executing AuthenticationController.doLogOut');
     const { access_token } = req.body;
 
+    if(!access_token){
+      logger.info('Access token not received.');
+      res.status(400).send({ message: 'Access token not received.' });
+      return;
+    }
+
     try {
       const decodedToken = verify(access_token, process.env.SECRET_KEY);
       const token_id = decodedToken.jti;

--- a/src/controllers/authenticationController.js
+++ b/src/controllers/authenticationController.js
@@ -56,8 +56,8 @@ export default class AuthenticationController {
     const { access_token } = req.body;
 
     if(!access_token){
-      logger.info('Access token not received.');
-      res.status(400).send({ message: 'Access token not received.' });
+      logger.info(Messages.TOKEN_REQUIRED);
+      res.status(400).send({ message: Messages.TOKEN_REQUIRED });
       return;
     }
 
@@ -67,10 +67,10 @@ export default class AuthenticationController {
       const result = await RejectListDAO.add({ token_id });
 
       if (result.success) {
-        logger.info('Logout successful.');
-        res.status(200).send({ message: 'Logout successful' });
+        logger.info(Messages.LOGOUT_SUCCESSFUL);
+        res.status(200).send({ message: Messages.LOGOUT_SUCCESSFUL });
       } else {
-        logger.error('Error during Logout - The system could not save the access token.');
+        logger.error('Error during Logout - The system could not save the token identifier.');
         res.status(500).send({ message: result.message });
       }
     } catch (err) {

--- a/src/controllers/authenticationController.js
+++ b/src/controllers/authenticationController.js
@@ -53,10 +53,10 @@ export default class AuthenticationController {
 
   static doLogOut = async (req, res) => {
     logger.info('Executing AuthenticationController.doLogOut');
-    const { token } = req;
+    const { access_token } = req.body;
 
     try {
-      const decodedToken = verify(token, process.env.SECRET_KEY);
+      const decodedToken = verify(access_token, process.env.SECRET_KEY);
       const token_id = decodedToken.jti;
       const result = await RejectListDAO.add({ token_id });
 
@@ -64,7 +64,7 @@ export default class AuthenticationController {
         logger.info('Logout successful.');
         res.status(200).send({ message: 'Logout successful' });
       } else {
-        logger.error('Error during Logout.');
+        logger.error('Error during Logout - The system could not save the access token.');
         res.status(500).send({ message: result.message });
       }
     } catch (err) {

--- a/src/routes/authenticationRouter.js
+++ b/src/routes/authenticationRouter.js
@@ -1,7 +1,6 @@
 import express from 'express';
 const authenticationRouter = express.Router();
 import AuthenticationController from '../controllers/authenticationController.js';
-// import AuthMiddleware from './middleware/authMiddleware.js';
 
 authenticationRouter.use(express.json());
 

--- a/src/routes/authenticationRouter.js
+++ b/src/routes/authenticationRouter.js
@@ -1,13 +1,13 @@
 import express from 'express';
 const authenticationRouter = express.Router();
 import AuthenticationController from '../controllers/authenticationController.js';
-import AuthMiddleware from './middleware/authMiddleware.js';
+// import AuthMiddleware from './middleware/authMiddleware.js';
 
 authenticationRouter.use(express.json());
 
 authenticationRouter
   .post('/login', AuthenticationController.doLogin)
-  .post('/logout', AuthMiddleware.checkToken, AuthenticationController.doLogOut)
+  .post('/logout', AuthenticationController.doLogOut)
   .post('/validate-password', AuthenticationController.validatePassword);
 
 export default authenticationRouter;

--- a/src/routes/middleware/authMiddleware.js
+++ b/src/routes/middleware/authMiddleware.js
@@ -29,6 +29,7 @@ export default class AuthMiddleware {
       const result = await RejectListDAO.getById(decodedToken.jti);
 
       if (result.success) {
+        // The token identifier was found in the database, it must not continue.
         return res
           .status(401)
           .send({ message: Messages.REJECT_LIST_INVALID_TOKEN });

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -14,6 +14,9 @@ export default class Messages {
   static ERROR_CHECKING_CREDENTIALS = 'Error checking credentials.';
   static ERROR_PROCESSING_FORGOT_PASSWORD = 'Error processing forgot password.';
 
+  // Login/Logout
+  static LOGOUT_SUCCESSFUL = 'Logout successful';
+
   // Access Token
   static TOKEN_REQUIRED = 'Access token required.';
   static TOKEN_EXPIRED = 'Token expired.';

--- a/thunder-collection_Glicocheck.json
+++ b/thunder-collection_Glicocheck.json
@@ -2,7 +2,7 @@
     "clientName": "Thunder Client",
     "collectionName": "Glicocheck",
     "collectionId": "a9cf7d89-7e3f-410e-928f-c83cbed2644f",
-    "dateExported": "2024-10-06T03:11:52.943Z",
+    "dateExported": "2024-10-12T18:55:52.780Z",
     "version": "1.2",
     "folders": [
         {
@@ -100,11 +100,11 @@
             "method": "POST",
             "sortNum": 5000,
             "created": "2024-02-13T19:33:44.026Z",
-            "modified": "2024-10-06T02:02:47.010Z",
+            "modified": "2024-10-12T03:03:31.363Z",
             "headers": [],
             "body": {
                 "type": "json",
-                "raw": "{\n    \"email\": \"juninho@gmail.com\",\n    \"password\": \"asd\"\n}",
+                "raw": "{\n    \"email\": \"costaeduardoluiz@gmail.com\",\n    \"password\": \"asd\"\n}",
                 "form": []
             }
         },
@@ -717,11 +717,11 @@
             "colId": "a9cf7d89-7e3f-410e-928f-c83cbed2644f",
             "containerId": "9e544e9b-68d9-460c-86b4-515ee3acaeb4",
             "name": "System health check",
-            "url": "{{LOCALHOST}}/api/ping",
+            "url": "https://glicocheck-api.onrender.com/api/ping",
             "method": "GET",
             "sortNum": 280000,
             "created": "2024-02-13T19:33:44.045Z",
-            "modified": "2024-09-07T23:53:56.914Z",
+            "modified": "2024-10-06T17:55:06.600Z",
             "headers": []
         },
         {
@@ -857,11 +857,12 @@
             "method": "POST",
             "sortNum": 370000,
             "created": "2024-06-11T01:27:14.087Z",
-            "modified": "2024-10-06T03:10:03.457Z",
+            "modified": "2024-10-12T18:55:22.551Z",
             "headers": [],
-            "auth": {
-                "type": "bearer",
-                "bearer": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjE3OGY2MWI0LTE4ZTUtNDhkMS1iZDcxLTQzZDRlYjZkN2ZiZSIsImp0aSI6ImM3MTk3NzdhLTMwNzYtNDI5NS1hYzc2LTE5MjdhNzNiZTIyZiIsImlhdCI6MTcyODE4MzgxMiwiZXhwIjoxNzI4MTg1NjEyfQ.lwz6i6XJzHXse0S2BCfNA203SXwj-9iSr3_Da5v5Eq0"
+            "body": {
+                "type": "json",
+                "raw": "{\n  \"access_token\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImRjZmRjMWEzLThmMmQtNGYyZS05MTA3LTgzYmFiYjRhN2U4ZiIsImp0aSI6ImE5ZWIwMjEzLWE2MzEtNDdkZC04YzA3LWVjMGVhZmI5N2YxNCIsImlhdCI6MTcyODcwMjIxMSwiZXhwIjoxNzI4NzA0MDExfQ.y5hSQtkYx4q-kcjzvEYqNcTfGxul6ucN0pk-tzzd568\"\n}",
+                "form": []
             }
         },
         {
@@ -889,5 +890,5 @@
     "settings": {
         "envId": "f0223d0d-c7c0-4d5a-b204-ecc7a093cbf2"
     },
-    "ref": "AacjCQHooDV61gcZhlKO5fx70mZFAbPBTqK8vEzOv8h7PJ-7ZMU4UoJUMYgs6WXDApu-D2vSu18eT_o1MJ3U6A"
+    "ref": "AacjCQHooDV61gcZhlKO5ZoVzsecQgTfquWkEgC6oA-0t--HfH-0L0-Jz7_4v6rEC9Y-iLTa1qUpDTgWPz-x3g"
 }


### PR DESCRIPTION
### Problem
- The logout method was receiving the access token via the Authorization header, but we were having problems with CORS when extracting this token and adding it to the rejected tokens table.

### Solution
- Resolves the logout issue, where the access token is sent in the request body and saved in the rejected token table.

### How To Test
- Do the login with valid credentials.
- Get the `access_token` in the login response.
- Inform the `access_token` in the body of logout method.
- Check in the database if the token was saved

### Fixes 
- #40 

