### PR TITLE
Extend user account deletion api to include all related data cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glicocheck-api",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "API for diabetes management.",
   "main": "index.js",
   "type": "module",

--- a/src/controllers/healthInfoController.js
+++ b/src/controllers/healthInfoController.js
@@ -13,7 +13,7 @@ class HealthInfoController {
       const result = await HealthInfoDAO.getAll();
 
       if (result.success) {
-        return res.status(201).json(result.healthInfo);
+        return res.status(200).json(result.healthInfo);
       } else {
         return res.status(500).json({ message: result.message });
       }
@@ -90,7 +90,7 @@ class HealthInfoController {
       const result = await HealthInfoDAO.getByUserId(userResult.user.id);
 
       if (result.success) {
-        return res.status(201).json(result.healthInfo);
+        return res.status(200).json(result.healthInfo);
       } else {
         return res.status(404).json({ message: result.message });
       }
@@ -129,7 +129,7 @@ class HealthInfoController {
       const result = await HealthInfoDAO.updateByUserId(id_user, healthInfo);
 
       if (result.success) {
-        res.status(200).json(result.healthInfo);
+        res.status(201).json(result.healthInfo);
       } else {
         // Add new Health info for this user.
         const resultAdd = await HealthInfoDAO.add({id_user,...healthInfo});
@@ -163,21 +163,17 @@ class HealthInfoController {
 
       // Retrives healthinfo by user id.
       let healthInfoResult = await HealthInfoDAO.getByUserId(userResult.user.id);
-
-      if (healthInfoResult.success) {
-        
-        // Deletes Health Info by id.
-        const healthInfoId = healthInfoResult.healthInfo.id;
-        healthInfoResult = await HealthInfoDAO.deleteById(healthInfoId);
-
-        if(healthInfoResult.success){
-          res.status(200).json({ message: healthInfoResult.message });
-        }else{
-          res.status(500).json({ message: Messages.ERROR });
-        }
-      } else {
-        res.status(404).json({ message: healthInfoResult.message });
+      if (!healthInfoResult.success) {
+        return res.status(404).json({ message: healthInfoResult.message });
       }
+        
+      // Deletes Health Info by id.
+      healthInfoResult = await HealthInfoDAO.deleteById(healthInfoResult.healthInfo.id);
+      if(healthInfoResult.success){
+        res.status(200).json({ message: healthInfoResult.message });
+      }else{
+        res.status(500).json({ message: Messages.ERROR });
+      }      
     } catch (error) {
       logger.error('Error HealthInfoController.deleteByUserCode.', error);
       res.status(500).json({ message: Messages.ERROR });

--- a/src/dao/HealthInfoDAO.js
+++ b/src/dao/HealthInfoDAO.js
@@ -80,13 +80,21 @@ export default class HealthInfoDAO {
     }
   }
 
-  static async deleteById(id) {
+  static async delete(condition) {
     try {
-      await database(TABLE_HEALTH_INFO).where('id', id).del();
+      await database(TABLE_HEALTH_INFO).where(condition).del();
       return { success: true, message: Messages.HEALTH_INFO_DELETED };
     } catch (error) {
-      logger.error('Error HealthInfoDAO.deleteById', error);
+      logger.error('Error HealthInfoDAO.delete', error);
       throw new Error(Messages.ERROR);
     }
+  }
+  
+  static async deleteById(id) {
+    return this.delete({ id });
+  }
+  
+  static async deleteByUserId(userId) {
+    return this.delete({ id_user: userId });
   }
 }

--- a/src/dao/UserDAO.js
+++ b/src/dao/UserDAO.js
@@ -88,6 +88,23 @@ export default class UserDAO {
     }
   }
 
+  static async getUserIdByUserCode(userCode) {
+    try {
+      const users = await database(TABLE_USERS)
+      .where('cod_user', userCode)
+      .select('users.id');
+
+      if (users.length > 0) {
+        return { success: true, userId: users[0].id };
+      } else {
+        return { success: false, message: Messages.USER_NOT_FOUND };
+      }
+    } catch (error) {
+      logger.error(`Error UserDAO.getByUserCode - Details: ${error}`);
+      throw new Error(Messages.ERROR);
+    }
+  }
+
   static async getByEmail(email) {
     try {     
       const users = await database(TABLE_USERS)
@@ -152,23 +169,12 @@ export default class UserDAO {
     return this.updateByCondition('email', email, updatedUser, 'Email');
   }
 
-  static async deleteByUserCode(userCode) {
+  static async deleteByUserId(userId) {
     try {
-      const users = await database(TABLE_USERS)
-        .where('cod_user', userCode)
-        .select('id');
-
-      if (users.length === 0) {
-        return { success: false, message: Messages.USER_NOT_FOUND };
-      } else {
-        const user = users[0];
-
-        await database(TABLE_USERS).where('id', user.id).del();
-
-        return { success: true, message: Messages.USER_DELETED };
-      }
+        await database(TABLE_USERS).where('id', userId).del();
+        return { success: true, message: Messages.USER_DELETED };      
     } catch (error) {
-      logger.error(`Error UserDAO.deleteByUserCode - Details: ${error}`);
+      logger.error(`Error UserDAO.deleteByUserId - Details: ${error}`);
       throw new Error(Messages.ERROR);
     }
   }

--- a/src/routes/usersRouter.js
+++ b/src/routes/usersRouter.js
@@ -27,7 +27,7 @@ usersRouter
   .delete('/:usercode',
     AuthMiddleware.checkToken,
     UserCodeMiddleware.validateUserCode,
-    UserController.deleteUserByUserCode
+    UserController.deleteUserAccountByUserCode
   );
 
 export default usersRouter;

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -36,7 +36,7 @@ export default class Messages {
   static NEW_DIARY_DATA_ADDED = 'New blood sugar diary register added.';
   static DIARY_DATA_DELETED = 'Blood sugar diary register deleted.';
   static ERROR_UPDATING_DIARY = 'Error updating blood sugar diary.';
-  static ERROR_DELETING_DIARY = 'Error deleting diary register.';
+  static ERROR_DELETING_DIARY = 'Error deleting diary registers.';
 
   // Gender
   static NEW_GENDER_CREATED = 'New gender created.';
@@ -73,6 +73,7 @@ export default class Messages {
   static SYSTEM_CONFIGURATION_DELETED = 'System configuration deleted.';
   static SYSTEM_CONFIGURATION_EXISTING = 'There is already a system configuration for this user.';
   static SAVED_DEFAULT_SYSTEM_CONFIGURATION = 'Saved default system configuration.';
+  static ERROR_DELETE_SYSTEM_CONFIGURATION = 'Error deleting system configuration.';
 
   // Marker meal
   static MARKER_MEAL_DELETED = 'Marker meal deleted.';
@@ -82,6 +83,7 @@ export default class Messages {
   static HEALTH_INFO_CREATED = 'New health info created.';
   static HEALTH_INFO_EXISTING = 'There is already health information registered for this user.';
   static HEALTH_INFO_DELETED = 'User\'s health info deleted.';
+  static ERROR_DELETE_HEALTH_INFO = 'Error deleting health info.';
 
   // Carbs counting
   static ERROR_LOADING_CARBS_COUTING_CREDENTIALS = 'Error loading EDAMAN\'s API credentials.';


### PR DESCRIPTION
### Problem
- The implementation of the "Delete User's Account" API was only removing the user's account information and not deleting other associated records.

### Solution
- This implementation updates the "Delete User's Account" API to include the deletion of associated records:
  - Glucose readings
  - System configuration
  - Health information
That ensures that all associated records are properly cascaded for deletion.

### How To Test
- Delete a user account and check whether the glucose readings, system configuration, and health information were also deleted.

### Fixes 
- #44 
